### PR TITLE
Add Date as primaryKey

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -41,7 +41,8 @@
             "type": "number",
             "description": ""
           }
-        ]
+        ],
+        "primaryKey": "Date"
       }
     }
   ],


### PR DESCRIPTION
If Date is primaryKey, plugins like jsontableschema-pandas-py can use it to automatically create a DatetimeIndex, making processing time series data like this more *frictionless*.

https://github.com/frictionlessdata/jsontableschema-pandas-py/issues/7

