### PR TITLE
Improve metadata: add descriptions, fix date format, document quirks, add sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 # Finance VIX
 
 CBOE Volatility Index (VIX) time-series dataset including daily open, close,
-high and low. The CBOE Volatility Index (VIX) is a key measure of market
-expectations of near-term volatility conveyed by S&P 500 stock index option
-prices introduced in 1993.
+high and low, covering January 1990 to present. The CBOE Volatility Index (VIX)
+is a key measure of market expectations of near-term volatility conveyed by
+S&P 500 stock index option prices introduced in 1993.
 
 ## Data
 
-From the [VIX FAQ][faq]:
+From the [CBOE VIX historical data page][historical]:
 
 > In 1993, the Chicago Board Options Exchange® (CBOE®) introduced the CBOE
 > Volatility Index®, VIX®, and it quickly became the benchmark for stock market
@@ -30,7 +30,16 @@ From the [VIX FAQ][faq]:
 > incorporates information from the volatility "skew" by using a wider range of
 > strike prices rather than just at-the-money series.
 
-[faq]: http://www.cboe.com/micro/vix/faq.aspx
+[historical]: https://www.cboe.com/tradable_products/vix/vix_historical_data/
+
+### Data quirks
+
+- **Early OHLC data (through 06/11/2004):** The first 506 rows of `vix-daily.csv`
+  have identical OPEN, HIGH, LOW, and CLOSE values. CBOE only recorded daily
+  closing values before mid-2004; the open/high/low fields are filled with the
+  close value for those dates.
+- **Monthly data:** `vix-monthly.csv` contains month-end closing values but is
+  not updated automatically by the workflow. Treat it as a static snapshot.
 
 ## Development
 
@@ -40,11 +49,12 @@ This is a simple pipeline where the only requirement is to have `curl` and `make
 make
 ```
 
+The daily data is fetched from:
+`https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv`
+
 ## License
 
 No obvious statement on [historical data page][historical]. Given size and
 factual nature of the data and its source from a US company would imagine this
 was public domain and as such have licensed the Data Package under the Public
 Domain Dedication and License (PDDL).
-
-[historical]: https://www.cboe.com/tradable_products/vix/vix_historical_data/

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,12 +1,20 @@
 {
   "name": "finance-vix",
   "title": "VIX - CBOE Volatility Index",
+  "description": "Daily and monthly time-series of the CBOE Volatility Index (VIX) from January 1990 to present, including open, high, low, and close values. VIX measures the market's expectation of 30-day S&P 500 volatility derived from options prices and is widely known as the 'fear gauge'.",
   "collection": "stock-market-data",
   "licenses": [
     {
       "name": "ODC-PDDL-1.0",
       "path": "http://opendatacommons.org/licenses/pddl/",
       "title": "Open Data Commons Public Domain Dedication and License v1.0"
+    }
+  ],
+  "sources": [
+    {
+      "name": "CBOE VIX Historical Data",
+      "path": "https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv",
+      "title": "CBOE VIX Daily Price History CSV"
     }
   ],
   "views": [
@@ -58,27 +66,59 @@
     {
       "name": "vix-monthly",
       "path": "data/vix-monthly.csv",
+      "description": "Month-end VIX closing values aggregated from the daily series. Note: this file is not updated automatically by the workflow and may be stale.",
       "format": "csv",
       "mediatype": "text/csv",
       "schema": {
         "fields": [
-          { "name": "Date", "type": "date", "format": "%Y-%m-%d" },
-          { "name": "Close", "type": "number", "description": "Month-end VIX closing value" }
+          {
+            "name": "Date",
+            "type": "date",
+            "format": "default",
+            "description": "Month-end date in YYYY-MM-DD format."
+          },
+          {
+            "name": "Close",
+            "type": "number",
+            "description": "Month-end VIX closing value"
+          }
         ]
       }
     },
     {
       "name": "vix-daily",
       "path": "data/vix-daily.csv",
+      "description": "Daily VIX open, high, low, and close values from January 1990 to present. Rows through 06/11/2004 (506 rows) have identical OPEN, HIGH, LOW, and CLOSE values because CBOE only recorded closing prices before that date.",
       "format": "csv",
       "mediatype": "text/csv",
       "schema": {
         "fields": [
-          { "name": "DATE", "type": "date", "format": "%m/%d/%Y" },
-          { "name": "OPEN", "type": "number" },
-          { "name": "HIGH", "type": "number" },
-          { "name": "LOW", "type": "number" },
-          { "name": "CLOSE", "type": "number" }
+          {
+            "name": "DATE",
+            "type": "date",
+            "format": "%m/%d/%Y",
+            "description": "Trading date in MM/DD/YYYY format."
+          },
+          {
+            "name": "OPEN",
+            "type": "number",
+            "description": "VIX opening value. Identical to CLOSE for dates on or before 06/11/2004."
+          },
+          {
+            "name": "HIGH",
+            "type": "number",
+            "description": "VIX intraday high. Identical to CLOSE for dates on or before 06/11/2004."
+          },
+          {
+            "name": "LOW",
+            "type": "number",
+            "description": "VIX intraday low. Identical to CLOSE for dates on or before 06/11/2004."
+          },
+          {
+            "name": "CLOSE",
+            "type": "number",
+            "description": "VIX closing value."
+          }
         ]
       }
     }


### PR DESCRIPTION
## Changes

- **`datapackage.json`** — add package-level `description`
- **`datapackage.json`** — add `sources` array pointing to `https://cdn.cboe.com/api/global/us_indices/daily_prices/VIX_History.csv`
- **`datapackage.json`** — add `description` to both resources (`vix-monthly`, `vix-daily`)
- **`datapackage.json`** — add `description` to all schema fields across both resources
- **`datapackage.json`** — fix `vix-monthly.Date` `format`: `"%Y-%m-%d"` → `"default"` (Frictionless canonical for ISO 8601)
- **`datapackage.json`** — document in `vix-daily` resource description that the first 506 rows (through 06/11/2004) have identical OPEN/HIGH/LOW/CLOSE because CBOE only recorded close values before mid-2004
- **`datapackage.json`** — note in `vix-monthly` description that this file is not auto-updated by the workflow
- **`README.md`** — replace broken FAQ link (`cboe.com/micro/vix/faq.aspx` redirected to a generic products page) with the working historical data page link
- **`README.md`** — add time range (January 1990 to present) to the opening paragraph
- **`README.md`** — add "Data quirks" section documenting the early OHLC issue and static monthly file
- **`README.md`** — add the actual data source URL so readers know where the CSV comes from